### PR TITLE
Default value for colors in `initialize-instance`

### DIFF
--- a/cram_bullet_reasoning/src/robot-model.lisp
+++ b/cram_bullet_reasoning/src/robot-model.lisp
@@ -217,7 +217,7 @@ of the object should _not_ be updated."
               (attach-object robot-object obj link-name)))))
 
 (defmethod initialize-instance :after ((robot-object robot-object)
-                                       &key color name pose
+                                       &key (color '(0.0 0.0 0.0 1.0)) name pose
                                          (collision-group :character-filter)
                                          (collision-mask '(:default-filter :static-filter)))
   (with-slots (rigid-bodies links urdf pose-reference-body) robot-object


### PR DESCRIPTION
Without a default value, URDFs (for example the iai_kitchen URDF) don't load anymore. The error comes up when an alpha value for the given color (defaulting to `nil`) is being accessed.