### PR TITLE
Perceive-objects: Use keywords rather than symbols

### DIFF
--- a/cram_bullet_reasoning_utilities/src/plan-library.lisp
+++ b/cram_bullet_reasoning_utilities/src/plan-library.lisp
@@ -38,7 +38,7 @@
                              (:at ,on-counter))))
     (reference on-counter)
     (format t "trying to perceive an object ~a~%" the-object)
-    (let ((perceived-object (plan-lib:perceive-object 'cram-plan-library:a the-object)))
+    (let ((perceived-object (plan-lib:perceive-object :a the-object)))
       (unless (desig-equal the-object perceived-object)
         (equate the-object perceived-object))
       the-object)))


### PR DESCRIPTION
As described in https://github.com/cram2/cram_plans/pull/3.